### PR TITLE
Route support orders to chat, add admin queue filters, and refresh background visuals

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -114,6 +114,38 @@
     font-family: var(--font-mono);
     letter-spacing: 0.02em;
     perspective: var(--perspective);
+    position: relative;
+    overflow-x: hidden;
+  }
+
+  body::before,
+  body::after {
+    content: '';
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: -1;
+  }
+
+  body::before {
+    background:
+      linear-gradient(120deg, rgba(255, 61, 144, 0.12), rgba(0, 255, 210, 0.08)),
+      radial-gradient(circle at 12% 18%, rgba(255, 221, 87, 0.18), transparent 40%),
+      radial-gradient(circle at 78% 22%, rgba(0, 184, 255, 0.18), transparent 45%),
+      radial-gradient(circle at 50% 78%, rgba(255, 69, 69, 0.16), transparent 42%),
+      repeating-linear-gradient(135deg, rgba(255, 255, 255, 0.02) 0 12px, transparent 12px 24px);
+    filter: saturate(160%);
+    opacity: 0.9;
+  }
+
+  body::after {
+    background:
+      repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.025) 0 1px, transparent 1px 6px),
+      repeating-linear-gradient(0deg, rgba(255, 255, 255, 0.02) 0 2px, transparent 2px 8px),
+      radial-gradient(circle at 20% 70%, rgba(255, 0, 180, 0.1), transparent 50%),
+      radial-gradient(circle at 85% 65%, rgba(0, 255, 150, 0.1), transparent 50%);
+    mix-blend-mode: screen;
+    opacity: 0.6;
   }
 
   h1, h2, h3, h4, h5, h6 {


### PR DESCRIPTION
### Motivation

- Fix the support experience so admin sees order submissions alongside regular support messages and the support UI navigates and highlights order items like other messages. 
- Improve admin-side visibility and tooling for support queues with filtering and clearer order intake styling. 
- Give the site a more interesting, Warhol/Basquiat-inspired background to match the requested visual direction.

### Description

- SupportChatBox: added an Orders tab and `addManualOrder` now creates `support_messages` with `message_type: 'order'` (so orders route into the same chat thread), disabled sending when support is closed, improved header with support status and chat meta, and removed the old local `orders` state in favor of server-driven messages. 
- Admin SupportManager: added queue filters (`all | open | pending | closed`) with counts, made the chat list use the chosen filter, and highlighted/styled `message_type === 'order'` messages (badge, amber styling and a note that the message was routed from the orders tab). 
- Visual / CSS: updated `src/index.css` to add layered gradients, radial accents and texture overlays (Warhol/Basquiat-inspired) via `body::before`/`::after` for a richer global background treatment. 
- Misc: updated icon imports and small UX text tweaks (chat ID preview, status badges, clearer orders UI and copy).

### Testing

- Ran `npm install` locally which produced environment warnings (e.g. `Unknown env config "http-proxy"`) and Node warnings about event listeners but completed without running the app. 
- Attempted to start the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, which failed with `sh: 1: vite: not found` so the app was not started and no end-to-end verification was performed. 
- Changes were lint/compile-unchecked and committed; no automated test suite was executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698221e0e8cc8332a85a497c01692a58)