### PR TITLE
Hide stock products from homepage featured section

### DIFF
--- a/src/pages/Homepage.tsx
+++ b/src/pages/Homepage.tsx
@@ -14,6 +14,7 @@ interface Product {
   short_description: string | null;
   price: number;
   category: string;
+  product_type: 'stock' | 'logz' | 'accounts';
   image_url: string | null;
   created_at: string;
 }
@@ -48,8 +49,9 @@ export default function Homepage() {
     setLoading(true);
     const { data, error } = await supabase
       .from('products')
-      .select('id, title, short_description, price, category, image_url, created_at')
+      .select('id, title, short_description, price, category, product_type, image_url, created_at')
       .eq('is_active', true)
+      .neq('product_type', 'stock')
       .order('created_at', { ascending: false })
       .limit(6);
     if (!error) setProducts(data || []);


### PR DESCRIPTION
### Motivation
- Prevent `product_type: 'stock'` items from appearing in the homepage featured products so stock listings are only shown via the `/stock` page.

### Description
- Add `product_type` to the `Product` interface and update the Supabase query in `src/pages/Homepage.tsx` to select `product_type` and exclude stock entries with `.neq('product_type', 'stock')`.

### Testing
- Ran `npm run build` (failed: `vite` not found because dependencies are not installed), `npm ci` (failed with `403 Forbidden` fetching npm packages), and attempted a Playwright screenshot (failed with `ERR_EMPTY_RESPONSE` because no app was running); no successful build or runtime test could be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699071beec488332a36aefb4547a267d)