### PR TITLE
Add Telegram + Web Push notifications for announcements and drops

### DIFF
--- a/src/components/admin/AnnouncementManager.tsx
+++ b/src/components/admin/AnnouncementManager.tsx
@@ -100,6 +100,15 @@ export default function AnnouncementManager() {
         toast.error('Failed to create announcement');
         console.error(error);
       } else {
+        await supabase.functions.invoke('broadcast-site-update', {
+          body: {
+            title: formData.title,
+            message: formData.message,
+            type: 'announcement',
+            link: '/announcements',
+            sendPush: true,
+          },
+        });
         toast.success('Announcement created');
         fetchAnnouncements();
         resetForm();

--- a/src/components/admin/DropManager.tsx
+++ b/src/components/admin/DropManager.tsx
@@ -75,6 +75,15 @@ export default function DropManager() {
     if (error) {
       toast.error('Failed to create drop');
     } else {
+      await supabase.functions.invoke('broadcast-site-update', {
+        body: {
+          title: `Free Drop: ${newDrop.title}`,
+          message: newDrop.description || 'A new free digital product drop is live now.',
+          type: 'drop',
+          link: '/announcements',
+          sendPush: true,
+        },
+      });
       toast.success('Drop created!');
       setNewDrop({ title: '', description: '', starts_at: '', ends_at: '', max_claims: '' });
       fetchDrops();

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1063,6 +1063,39 @@ export type Database = {
         }
         Relationships: []
       }
+      push_subscriptions: {
+        Row: {
+          auth: string
+          created_at: string
+          endpoint: string
+          id: string
+          p256dh: string
+          updated_at: string
+          user_agent: string | null
+          user_id: string
+        }
+        Insert: {
+          auth: string
+          created_at?: string
+          endpoint: string
+          id?: string
+          p256dh: string
+          updated_at?: string
+          user_agent?: string | null
+          user_id: string
+        }
+        Update: {
+          auth?: string
+          created_at?: string
+          endpoint?: string
+          id?: string
+          p256dh?: string
+          updated_at?: string
+          user_agent?: string | null
+          user_id?: string
+        }
+        Relationships: []
+      }
       site_settings: {
         Row: {
           created_at: string

--- a/src/lib/notifications.md
+++ b/src/lib/notifications.md
@@ -1,0 +1,26 @@
+# Telegram + Push Notification Setup
+
+This project now supports:
+
+1. **Telegram group updates** via `broadcast-site-update` edge function.
+2. **Phone push notifications** for installed app users who enable notifications.
+
+## Required Supabase secrets
+
+Set these in Supabase Edge Functions secrets:
+
+- `TELEGRAM_BOT_TOKEN`
+- `TELEGRAM_CHAT_ID`
+- `VAPID_SUBJECT` (ex: `mailto:admin@yoursite.com`)
+- `VAPID_PUBLIC_KEY`
+- `VAPID_PRIVATE_KEY`
+
+Also set frontend env var:
+
+- `VITE_VAPID_PUBLIC_KEY`
+
+## Usage
+
+- Creating a new announcement in Admin will broadcast to Telegram + push.
+- Creating a new drop in Admin will broadcast to Telegram + push.
+- Users can open `/install` and click **Enable Notifications** to register their phone/app for push.

--- a/src/pages/Install.tsx
+++ b/src/pages/Install.tsx
@@ -1,18 +1,29 @@
 import { useState, useEffect } from 'react';
-import { Download, Smartphone, CheckCircle, X, Terminal } from 'lucide-react';
+import { Download, Smartphone, CheckCircle, X, Terminal, Bell, BellOff } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import MainLayout from '@/components/layout/MainLayout';
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from 'sonner';
 
 interface BeforeInstallPromptEvent extends Event {
   prompt(): Promise<void>;
   userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
 }
 
+const urlBase64ToUint8Array = (base64String: string) => {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const rawData = window.atob(base64);
+  return Uint8Array.from([...rawData].map((char) => char.charCodeAt(0)));
+};
+
 export default function Install() {
   const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
   const [isInstalled, setIsInstalled] = useState(false);
   const [isIOS, setIsIOS] = useState(false);
   const [isStandalone, setIsStandalone] = useState(false);
+  const [notificationsEnabled, setNotificationsEnabled] = useState(false);
+  const [notificationLoading, setNotificationLoading] = useState(false);
 
   useEffect(() => {
     // Check if already installed
@@ -27,6 +38,10 @@ export default function Install() {
     const iOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
     setIsIOS(iOS);
 
+    if (Notification.permission === 'granted') {
+      setNotificationsEnabled(true);
+    }
+
     // Listen for install prompt
     const handleBeforeInstallPrompt = (e: Event) => {
       e.preventDefault();
@@ -34,7 +49,7 @@ export default function Install() {
     };
 
     window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
-    
+
     // Listen for app installed
     window.addEventListener('appinstalled', () => {
       setIsInstalled(true);
@@ -48,31 +63,101 @@ export default function Install() {
 
   const handleInstall = async () => {
     if (!deferredPrompt) return;
-    
+
     deferredPrompt.prompt();
     const { outcome } = await deferredPrompt.userChoice;
-    
+
     if (outcome === 'accepted') {
       setIsInstalled(true);
     }
     setDeferredPrompt(null);
   };
 
+  const handleEnableNotifications = async () => {
+    try {
+      setNotificationLoading(true);
+
+      if (!('serviceWorker' in navigator) || !('PushManager' in window)) {
+        toast.error('Push notifications are not supported on this browser');
+        return;
+      }
+
+      const vapidPublicKey = import.meta.env.VITE_VAPID_PUBLIC_KEY;
+      if (!vapidPublicKey) {
+        toast.error('Notification keys are not configured');
+        return;
+      }
+
+      const { data: userData, error: userError } = await supabase.auth.getUser();
+      if (userError || !userData.user) {
+        toast.error('Please log in first to enable notifications');
+        return;
+      }
+
+      const permission = await Notification.requestPermission();
+      if (permission !== 'granted') {
+        toast.error('Notification permission was not granted');
+        return;
+      }
+
+      const registration = await navigator.serviceWorker.ready;
+      const existingSubscription = await registration.pushManager.getSubscription();
+      const subscription =
+        existingSubscription ||
+        (await registration.pushManager.subscribe({
+          userVisibleOnly: true,
+          applicationServerKey: urlBase64ToUint8Array(vapidPublicKey),
+        }));
+
+      const subscriptionJson = subscription.toJSON();
+      const keys = subscriptionJson.keys;
+
+      if (!subscriptionJson.endpoint || !keys?.p256dh || !keys?.auth) {
+        toast.error('Could not read push subscription keys');
+        return;
+      }
+
+      const { error } = await supabase.from('push_subscriptions').upsert(
+        {
+          user_id: userData.user.id,
+          endpoint: subscriptionJson.endpoint,
+          p256dh: keys.p256dh,
+          auth: keys.auth,
+          user_agent: navigator.userAgent,
+        },
+        { onConflict: 'endpoint' },
+      );
+
+      if (error) {
+        toast.error('Failed to save notification subscription');
+        return;
+      }
+
+      setNotificationsEnabled(true);
+      toast.success('Phone notifications enabled');
+    } catch (error) {
+      console.error(error);
+      toast.error('Failed to enable notifications');
+    } finally {
+      setNotificationLoading(false);
+    }
+  };
+
   return (
     <MainLayout>
       <div className="min-h-screen relative">
         <div className="pointer-events-none fixed inset-0 opacity-[0.03] bg-[linear-gradient(rgba(0,255,150,0.2)_1px,transparent_1px)] bg-[size:100%_3px] z-10" />
-        
+
         <div className="container mx-auto px-4 py-8 sm:py-16 relative z-20">
           <div className="max-w-lg mx-auto text-center">
             <div className="inline-flex items-center justify-center w-20 h-20 rounded-full bg-primary/20 border border-primary/30 mb-6">
               <Smartphone className="w-10 h-10 text-primary" />
             </div>
-            
+
             <h1 className="text-2xl sm:text-3xl font-mono font-bold text-primary terminal-glow mb-4">
               INSTALL_APP://
             </h1>
-            
+
             {isStandalone || isInstalled ? (
               <div className="panel-3d rounded-lg p-6 sm:p-8">
                 <CheckCircle className="w-12 h-12 text-primary mx-auto mb-4" />
@@ -109,7 +194,7 @@ export default function Install() {
                 <p className="text-muted-foreground font-mono mb-6">
                   Install HELL5TAR for quick access, offline support, and a native app experience.
                 </p>
-                <Button 
+                <Button
                   className="crt-button px-8 py-6 text-lg font-mono w-full sm:w-auto"
                   onClick={handleInstall}
                 >
@@ -128,6 +213,21 @@ export default function Install() {
                 </p>
               </div>
             )}
+
+            <div className="mt-4 panel-3d rounded-lg p-4 sm:p-5 text-left">
+              <p className="text-sm font-mono text-primary mb-3">PHONE_NOTIFICATIONS://</p>
+              <p className="text-xs text-muted-foreground font-mono mb-4">
+                Enable push notifications to get instant alerts for site updates and free digital drops.
+              </p>
+              <Button
+                className="crt-button w-full"
+                onClick={handleEnableNotifications}
+                disabled={notificationLoading || notificationsEnabled}
+              >
+                {notificationsEnabled ? <Bell className="w-4 h-4 mr-2" /> : <BellOff className="w-4 h-4 mr-2" />}
+                {notificationLoading ? 'ENABLING...' : notificationsEnabled ? 'NOTIFICATIONS_ENABLED' : 'ENABLE_NOTIFICATIONS'}
+              </Button>
+            </div>
 
             <div className="mt-8 grid grid-cols-1 sm:grid-cols-3 gap-4">
               {[

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,0 +1,41 @@
+/// <reference lib="webworker" />
+import { precacheAndRoute } from 'workbox-precaching';
+
+declare let self: ServiceWorkerGlobalScope & { __WB_MANIFEST: Array<{ url: string; revision: string | null }> };
+
+precacheAndRoute(self.__WB_MANIFEST);
+
+self.addEventListener('push', (event) => {
+  if (!event.data) return;
+
+  const data = event.data.json();
+  const title = data.title || 'New update';
+  const options: NotificationOptions = {
+    body: data.body || 'New content is available',
+    icon: '/pwa-192x192.png',
+    badge: '/pwa-192x192.png',
+    tag: data.tag || 'site-update',
+    data: {
+      url: data.url || '/',
+    },
+  };
+
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const targetUrl = (event.notification.data?.url as string) || '/';
+
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientList) => {
+      for (const client of clientList) {
+        if ('focus' in client) {
+          client.navigate(targetUrl);
+          return client.focus();
+        }
+      }
+      return self.clients.openWindow(targetUrl);
+    }),
+  );
+});

--- a/supabase/functions/broadcast-site-update/index.ts
+++ b/supabase/functions/broadcast-site-update/index.ts
@@ -1,0 +1,126 @@
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.57.4";
+import webpush from "npm:web-push@3.6.7";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+const TELEGRAM_BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN");
+const TELEGRAM_CHAT_ID = Deno.env.get("TELEGRAM_CHAT_ID");
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+
+const VAPID_SUBJECT = Deno.env.get("VAPID_SUBJECT");
+const VAPID_PUBLIC_KEY = Deno.env.get("VAPID_PUBLIC_KEY");
+const VAPID_PRIVATE_KEY = Deno.env.get("VAPID_PRIVATE_KEY");
+
+if (VAPID_SUBJECT && VAPID_PUBLIC_KEY && VAPID_PRIVATE_KEY) {
+  webpush.setVapidDetails(VAPID_SUBJECT, VAPID_PUBLIC_KEY, VAPID_PRIVATE_KEY);
+}
+
+type BroadcastRequest = {
+  title: string;
+  message: string;
+  link?: string;
+  type: "announcement" | "drop" | "product" | "custom";
+  sendPush?: boolean;
+};
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const { title, message, link, type, sendPush = true }: BroadcastRequest = await req.json();
+
+    if (!title || !message || !type) {
+      return new Response(JSON.stringify({ error: "title, message and type are required" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json", ...corsHeaders },
+      });
+    }
+
+    const telegramText = [`📣 *${title}*`, "", message, link ? `\n🔗 ${link}` : ""].join("\n");
+
+    let telegramResult: { sent: boolean; error?: unknown } = { sent: false };
+    if (TELEGRAM_BOT_TOKEN && TELEGRAM_CHAT_ID) {
+      const telegramResponse = await fetch(`https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          chat_id: TELEGRAM_CHAT_ID,
+          text: telegramText,
+          parse_mode: "Markdown",
+          disable_web_page_preview: false,
+        }),
+      });
+
+      const telegramJson = await telegramResponse.json();
+      telegramResult = {
+        sent: telegramResponse.ok,
+        error: telegramResponse.ok ? undefined : telegramJson,
+      };
+    }
+
+    let pushSent = 0;
+    if (sendPush && VAPID_SUBJECT && VAPID_PUBLIC_KEY && VAPID_PRIVATE_KEY) {
+      const { data: subscriptions, error } = await supabase
+        .from("push_subscriptions")
+        .select("id, endpoint, p256dh, auth");
+
+      if (error) {
+        throw error;
+      }
+
+      for (const subscription of subscriptions ?? []) {
+        try {
+          await webpush.sendNotification(
+            {
+              endpoint: subscription.endpoint,
+              keys: {
+                p256dh: subscription.p256dh,
+                auth: subscription.auth,
+              },
+            },
+            JSON.stringify({
+              title,
+              body: message,
+              url: link ?? "/",
+              tag: `site-${type}`,
+            }),
+          );
+          pushSent += 1;
+        } catch (pushError) {
+          const statusCode = (pushError as { statusCode?: number }).statusCode;
+          if (statusCode === 404 || statusCode === 410) {
+            await supabase.from("push_subscriptions").delete().eq("id", subscription.id);
+          }
+          console.error("Failed to send push notification", pushError);
+        }
+      }
+    }
+
+    return new Response(
+      JSON.stringify({
+        ok: true,
+        telegram: telegramResult,
+        pushSent,
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json", ...corsHeaders },
+      },
+    );
+  } catch (error) {
+    console.error("broadcast-site-update error", error);
+    return new Response(JSON.stringify({ error: (error as Error).message }), {
+      status: 500,
+      headers: { "Content-Type": "application/json", ...corsHeaders },
+    });
+  }
+});

--- a/supabase/migrations/20260217090000_add_push_subscriptions.sql
+++ b/supabase/migrations/20260217090000_add_push_subscriptions.sql
@@ -1,0 +1,37 @@
+create table if not exists public.push_subscriptions (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  endpoint text not null unique,
+  p256dh text not null,
+  auth text not null,
+  user_agent text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create trigger update_push_subscriptions_updated_at
+before update on public.push_subscriptions
+for each row execute function public.update_updated_at_column();
+
+alter table public.push_subscriptions enable row level security;
+
+create policy "Users can view own push subscriptions"
+on public.push_subscriptions
+for select
+using (auth.uid() = user_id);
+
+create policy "Users can create own push subscriptions"
+on public.push_subscriptions
+for insert
+with check (auth.uid() = user_id);
+
+create policy "Users can update own push subscriptions"
+on public.push_subscriptions
+for update
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+create policy "Users can delete own push subscriptions"
+on public.push_subscriptions
+for delete
+using (auth.uid() = user_id);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,9 @@ export default defineConfig(({ mode }) => ({
     mode === "development" && componentTagger(),
     VitePWA({
       registerType: "autoUpdate",
+      strategies: "injectManifest",
+      srcDir: "src",
+      filename: "sw.ts",
       includeAssets: ["favicon.ico", "robots.txt"],
       manifest: {
         name: "HELL5TAR Network",


### PR DESCRIPTION
### Motivation
- Provide real-time updates to a Telegram group when the site publishes announcements or free digital product drops. 
- Deliver phone push notifications to app users who install the PWA and opt in, so downloads/updates reach users on their device.
- Centralize broadcasting so admins can trigger both Telegram and Web Push from existing admin flows.

### Description
- Added a Supabase Edge Function `broadcast-site-update` that posts messages to Telegram via the bot API and sends Web Push notifications to subscriptions stored in the DB using `web-push`.
- Created a DB migration `supabase/migrations/20260217090000_add_push_subscriptions.sql` to add a `push_subscriptions` table with RLS policies for per-user storage and maintenance triggers.
- Wired admin flows to invoke the broadcast function after successful creation: `src/components/admin/AnnouncementManager.tsx` and `src/components/admin/DropManager.tsx` now call `supabase.functions.invoke('broadcast-site-update', ...)`.
- Implemented client-side subscription flow in `src/pages/Install.tsx` to request permission, subscribe via `PushManager`, and `upsert` the subscription into `push_subscriptions` using the Supabase client.
- Added a custom service worker `src/sw.ts` with `push` and `notificationclick` handlers and switched `vite-plugin-pwa` to `injectManifest` (configured in `vite.config.ts`) so the SW is bundled and used.
- Updated generated Supabase types in `src/integrations/supabase/types.ts` to include the `push_subscriptions` table and added `src/lib/notifications.md` with setup notes for Telegram and VAPID secrets.

### Testing
- Ran `npm run build` to validate the app build, which failed because `vite` was not available in this environment (no dependency install); build did not complete.
- Ran `npm i` and `bun install` to install dependencies, both were blocked by registry `403 Forbidden` responses so package installation and local build/test runs were not possible.
- Attempted a Playwright page check to capture `/install`, which failed with `ERR_EMPTY_RESPONSE` because the local dev server could not be started due to the dependency installation failure.
- No runtime deployment or integration tests were executed here; the Edge Function, migration and client changes were added and should be validated by deploying the migration and Edge Function and by testing notification flows end-to-end (Telegram bot secrets, Supabase service role key, VAPID keys and `VITE_VAPID_PUBLIC_KEY`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69915572bfe88332aa886f230c7bc5e5)