### PR TITLE
Allow 'giftcards' in products.product_type check

### DIFF
--- a/supabase/migrations/20260303120000_expand_products_product_type_check.sql
+++ b/supabase/migrations/20260303120000_expand_products_product_type_check.sql
@@ -1,0 +1,9 @@
+-- Allow gift card stock rows to be inserted into products
+ALTER TABLE public.products
+DROP CONSTRAINT IF EXISTS products_product_type_check;
+
+ALTER TABLE public.products
+ADD CONSTRAINT products_product_type_check
+CHECK (product_type IN ('stock', 'logz', 'accounts', 'giftcards'));
+
+COMMENT ON COLUMN public.products.product_type IS 'Type of product: stock (cards/bins), logz (logs/dumps), accounts (account logins), giftcards (gift card inventory)';


### PR DESCRIPTION
### Motivation
- Inserts of gift card stock rows were failing with: `new row for relation "products" violates check constraint "products_product_type_check"` because `product_type='giftcards'` was not allowed by the table constraint. 
- The admin UI and `GiftCardManager` create products with `product_type: 'giftcards'`, so the schema must permit that value to avoid runtime errors.

### Description
- Added a new migration `supabase/migrations/20260303120000_expand_products_product_type_check.sql` that drops the existing `products_product_type_check` and recreates it to allow `('stock', 'logz', 'accounts', 'giftcards')`.
- Updated the column comment on `public.products.product_type` to include the new `giftcards` type for documentation clarity.
- The migration file was added and committed to the repository.

### Testing
- Ran `npm run lint` in this environment and it failed due to a missing dev dependency (`@eslint/js`), so automated linting could not be verified here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a698dd2f808332a102f3afa9fe597b)